### PR TITLE
Add note on making CMPLXFOIL super fast to build instructions

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -48,6 +48,9 @@ Copy a configuration file to the main ``config/`` folder using the command below
 
     cp config/defaults/config.<version>.mk config/config.mk
 
+.. note::
+    We have found that replacing ``-O2`` with ``-Ofast -march=native`` can make CMPLXFOIL almost 2x faster, but the ``Ofast`` optimizations are technically unsafe so we leave them out by default. 
+
 Once the configuration file is adjusted as needed, CMPLXFOIL can be built by running ``make`` in the root directory:
 
 .. prompt:: bash


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->

I found that I got a ~2x speedup from replacing `-O2` with `-Ofast -march=native` in my build config and the regression tests against reference values still passed. I think we probably don't want to make these the default flags because `Ofast` in unsafe and `march=native` might mess with the conda build but I added a note to the docs for people who are building CMPLXFOIL locally themselves.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1 day

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
