### PR TITLE
Fix crash in fortran layer

### DIFF
--- a/cmplxfoil/__init__.py
+++ b/cmplxfoil/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 from .CMPLXFOIL import CMPLXFOIL
 

--- a/src/xoper.f
+++ b/src/xoper.f
@@ -918,12 +918,12 @@ C------ set updated CL,CD
         CALL CDCALC
 C
 C------ display changes and test for convergence
-c        IF(RLX.LT.1.0)
-c     &   WRITE(*,2000) ITER, RMSBL, RMXBL, VMXBL,IMXBL,ISMXBL,RLX
-c        IF(RLX.EQ.1.0)
-c     &   WRITE(*,2010) ITER, RMSBL, RMXBL, VMXBL,IMXBL,ISMXBL
-c        CDP = CD - CDF
-c         WRITE(*,2020) ALFA/DTOR, CL, CM, CD, CDF, CDP
+        IF(RLX.LT.1.0)
+     &   WRITE(*,2000) ITER, RMSBL, RMXBL, VMXBL,IMXBL,ISMXBL,RLX
+        IF(RLX.EQ.1.0)
+     &   WRITE(*,2010) ITER, RMSBL, RMXBL, VMXBL,IMXBL,ISMXBL
+        CDP = CD - CDF
+         WRITE(*,2020) ALFA/DTOR, CL, CM, CD, CDF, CDP
 C
         IF(RMSBL .LT. EPS1) THEN
          LVCONV = .TRUE.

--- a/src/xoper.f
+++ b/src/xoper.f
@@ -117,6 +117,8 @@ C	 ADEG = 0.0	SET IN XFOIL.F NOW
        ENDIF
 C
        IF(LVISC) CALL VISCAL(ITMAX)
+c      return now if the VISCAL call failed
+       IF(LEXITFLAG) RETURN
 C       CALL CPX
        CALL FCPMIN
 
@@ -819,6 +821,8 @@ C----- locate stagnation point arc length position and panel index
 C
 C----- set  BL position -> panel position  pointers
        CALL IBLPAN
+c      quit if the boundary layer array overflows
+       IF(LEXITFLAG) RETURN
 C
 C----- calculate surface arc length array for current stagnation point location
        CALL XICALC

--- a/src/xpanel.f
+++ b/src/xpanel.f
@@ -1427,9 +1427,10 @@ C
 C
       IBLMAX = MAX(IBLTE(1),IBLTE(2)) + NW
       IF(IBLMAX.GT.IVX) THEN
-C        WRITE(*,*) ' ***  BL array overflow.'
-C        WRITE(*,*) ' ***  Increase IVX to at least', IBLMAX
-        STOP
+        WRITE(*,*) 'BL array overflow, setting LEXITFLAG to true'
+        LEXITFLAG = .TRUE.
+        LVCONV = .FALSE.
+        RETURN
       ENDIF
 C
       LIPAN = .TRUE.

--- a/src_cs/c_xoper.f
+++ b/src_cs/c_xoper.f
@@ -122,7 +122,8 @@ cs       write(*,*) 'invicid CL',CL
 c          write(*,*) 'calling viscal'
           call VISCAL(ITMAX)
        endif
-
+c      return now if the VISCAL call failed
+       IF(LEXITFLAG) RETURN
 C       CALL CPX
        CALL FCPMIN
 
@@ -848,6 +849,8 @@ C----- locate stagnation point arc length position and panel index
 C
 C----- set  BL position -> panel position  pointers
        CALL IBLPAN
+c      quit if the boundary layer array overflows
+       IF(LEXITFLAG) RETURN
 C
 C----- calculate surface arc length array for current stagnation point location
        CALL XICALC

--- a/src_cs/c_xpanel.f
+++ b/src_cs/c_xpanel.f
@@ -1496,9 +1496,10 @@ C
 C
       IBLMAX = MAX(IBLTE(1),IBLTE(2)) + NW
       IF(IBLMAX.GT.IVX) THEN
-C        WRITE(*,*) ' ***  BL array overflow.'
-C        WRITE(*,*) ' ***  Increase IVX to at least', IBLMAX
-        STOP
+        WRITE(*,*) 'BL array overflow, setting LEXITFLAG to true'
+        LEXITFLAG = .TRUE.
+        LVCONV = .FALSE.
+        RETURN
       ENDIF
 C
       LIPAN = .TRUE.


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
With particularly bad airfoil shapes, the `IBLPAN` function fails. Upon failure, it calls the `STOP` command. This kills not only the XFOIL instance, but also the whole Python script (not good during optimization...).

This PR removes the `STOP` command, instead setting fail flags accordingly and cleanly exiting back to the Python layer.

I also uncommented the residual printout in the real version of CMPLXFOIL so that the user gets some feedback on convergence behavior during the primal solve.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
Now!

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
