### PR TITLE
Match complex version convergence tolerances to real version

### DIFF
--- a/cmplxfoil/__init__.py
+++ b/cmplxfoil/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 from .CMPLXFOIL import CMPLXFOIL
 

--- a/src_cs/c_xbl.f
+++ b/src_cs/c_xbl.f
@@ -929,7 +929,7 @@ C----------------------------------------------------
       complex SENNEW
 ccc   REAL MDI
 C
-      DATA DEPS / 5.0E-6 /
+      DATA DEPS / 5.0E-4 /
 C
 C---- constant controlling how far Hk is allowed to deviate
 C-    from the specified value.

--- a/src_cs/c_xoper.f
+++ b/src_cs/c_xoper.f
@@ -823,8 +823,7 @@ C----------------------------------------
       include 'c_XFOIL.INC'
 C
 C---- convergence tolerance
-c      DATA EPS1 / 1.0E-10 /
-      DATA EPS1 / 1.0E-6 /
+      DATA EPS1 / 1.0E-10 /
 C
       NITER = NITER1
 C


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
In some cases, the primal (real) version of XFOIL converges fine, but then the gradient evaluation with the complex version does not converge. Optimizers very much dislike when the primal succeeds and the gradient fails. Most just crash.

One of the reasons I found for this happening is that the tolerances of the real and complex XFOIL versions do not match. This PR fixes this problem. This does not solve all of the situations where the primal succeeds and gradient fails, but it helps many of them. Furthermore, converging the complex evaluations more tightly (by four orders more than before) dramatically improves optimizer convergence near the optimum design, presumably because of more accurate gradients.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
ASAP as possible

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
